### PR TITLE
Remove logging configuration from library

### DIFF
--- a/src/countryflag/__init__.py
+++ b/src/countryflag/__init__.py
@@ -36,7 +36,6 @@ import platform
 import sys
 from typing import Any, Dict, List, Optional, Tuple, Union
 
-
 from countryflag.core.exceptions import (
     CacheError,
     CountryFlagError,

--- a/src/countryflag/__init__.py
+++ b/src/countryflag/__init__.py
@@ -36,11 +36,6 @@ import platform
 import sys
 from typing import Any, Dict, List, Optional, Tuple, Union
 
-# Set up logging
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
-)
 
 from countryflag.core.exceptions import (
     CacheError,


### PR DESCRIPTION
Libraries should not configure the root logger as it can interfere with application logging setup. Removed logging.basicConfig() call to allow applications to control their own logging configuration.

Fixes #4